### PR TITLE
enumerate all processes even if we cannot read the executable type

### DIFF
--- a/source/extensions/stdapi/server/sys/process/ps.c
+++ b/source/extensions/stdapi/server/sys/process/ps.c
@@ -745,7 +745,7 @@ void uid_to_username(struct info_user_list * user_list, int uid, char * username
 DWORD ps_list_linux( Packet * response )
 {
 	DWORD result = ERROR_NOT_SUPPORTED;
-	DWORD arch = PROCESS_ARCH_UNKNOWN; /* ELFCLASSNONE */
+	DWORD arch;
 	DIR * dir;
 	int i;
 	int read;
@@ -831,29 +831,31 @@ DWORD ps_list_linux( Packet * response )
 							file_buffer[i] = ' ';
 				}
 
+				arch = PROCESS_ARCH_UNKNOWN; /* ELFCLASSNONE */
+
 				memset(file_path, 0, sizeof(file_path));
 				snprintf(file_path, sizeof(file_path)-1, "/proc/%s/exe", entry->d_name);
 				fd = fopen(file_path, "rb");
-				if (!fd)
-					continue;
+				if (fd) {
+					memset(file_buffer, 0, sizeof(file_buffer));
+					read_file(fd, file_buffer, sizeof(file_buffer));
+					fclose(fd);
 
-				memset(file_buffer, 0, sizeof(file_buffer));
-				read_file(fd, file_buffer, sizeof(file_buffer));
-				fclose(fd);
-
-				/* ELFCLASS32 */
-				if (file_buffer[4] == 1) {
-					arch = PROCESS_ARCH_X86;
+					/* ELFCLASS32 */
+					if (file_buffer[4] == 1) {
+						arch = PROCESS_ARCH_X86;
+					}
+					/* ELFCLASS64 */
+					else if (file_buffer[4] == 2) {
+						arch = PROCESS_ARCH_X64;
+					}
 				}
-				/* ELFCLASS64 */
-				else if (file_buffer[4] == 2) {
-					arch = PROCESS_ARCH_X64;
-				}
 
-				ps_addresult(response, atoi(entry->d_name), info.ppid, process_name, cmdline, username, arch);
+				ps_addresult(response, atoi(entry->d_name),
+					info.ppid, process_name, cmdline, username, arch);
+
 				// at least 1 process found, return ERROR_SUCCESS;
 				result = ERROR_SUCCESS;
-
 				
 			} // end is_process_dir
 


### PR DESCRIPTION
This allows enumerating all of the processes even if we don't have privs on them.